### PR TITLE
Add details flag

### DIFF
--- a/cmd/protocol.go
+++ b/cmd/protocol.go
@@ -20,7 +20,7 @@ func init() {
 }
 
 func http(cmd *cobra.Command, args []string) {
-	renderer := &renderer.Printer{Port: Port, Addr: Address, BuildInfo: BuildInfo}
+	renderer := &renderer.Printer{Port: Port, Addr: Address, BuildInfo: BuildInfo, Details: Details}
 	httpServer := server.Http{Addr: Address, Port: Port, ResponseCode: ResponseCode, Output: renderer}
 	httpServer.Start()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ var (
 	Port         int
 	ResponseCode int
 	BuildInfo    map[string]string
+	Details      bool
 )
 
 var rootCmd = &cobra.Command{
@@ -26,4 +27,5 @@ func init() {
 	rootCmd.PersistentFlags().IntVarP(&Port, "port", "p", 8080, "sets the port for the endpoint")
 	rootCmd.PersistentFlags().StringVarP(&Address, "address", "a", "localhost", "sets the address for the endpoint")
 	rootCmd.PersistentFlags().IntVarP(&ResponseCode, "response_code", "r", 200, "sets the response code")
+	rootCmd.PersistentFlags().BoolVar(&Details, "details", false, "shows header details in the request")
 }

--- a/pkg/renderer/printer.go
+++ b/pkg/renderer/printer.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sort"
+	"strings"
 
 	"github.com/aaronvb/logrequest"
 	"github.com/pterm/pterm"
@@ -21,6 +23,9 @@ type Printer struct {
 
 	// Contains build info
 	BuildInfo map[string]string
+
+	// Determines if header details should be shown with the request
+	Details bool
 }
 
 // Start renders the initial header and the spinner. The Spinner should be consistent during
@@ -63,7 +68,7 @@ func (p *Printer) Fatal(err error) {
 }
 
 // IncomingRequest handles the output for incoming requests to the server.
-func (p *Printer) IncomingRequest(fields logrequest.RequestFields, params string) {
+func (p *Printer) IncomingRequest(fields logrequest.RequestFields, params string, headers map[string][]string) {
 	p.Spinner.Stop()
 	prefix := pterm.Prefix{
 		Text:  fields.Method,
@@ -72,6 +77,12 @@ func (p *Printer) IncomingRequest(fields logrequest.RequestFields, params string
 
 	text := p.incomingRequestText(fields, params)
 	pterm.Info.WithPrefix(prefix).Println(text)
+
+	if p.Details {
+		table := p.incomingRequestHeadersTable(headers)
+		pterm.Printf("%s\n\n", table)
+	}
+
 	p.startSpinner()
 }
 
@@ -83,6 +94,35 @@ func (p *Printer) incomingRequestText(fields logrequest.RequestFields, params st
 
 	text := fmt.Sprintf("%s %s", urlWithStyle, paramsWithStyle)
 	return text
+}
+
+// incomingRequestHeadersTable constructs the headers table string.
+// This takes the headers map from the request and sorts it alphabetically by key.
+func (p *Printer) incomingRequestHeadersTable(headers map[string][]string) string {
+	keys := make([]string, 0, len(headers))
+	for key := range headers {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	var headersFormatted [][]string
+
+	headerRow := []string{"Header", "Value"}
+	headersFormatted = append(headersFormatted, headerRow)
+
+	for _, key := range keys {
+		value := strings.Join(headers[key], ",")
+		headersRow := []string{key, value}
+		headersFormatted = append(headersFormatted, headersRow)
+	}
+
+	headersTable, err := pterm.DefaultTable.WithHasHeader().WithData(headersFormatted).Srender()
+	if err != nil {
+		pterm.Error.WithShowLineNumber(false).Println(err)
+	}
+
+	return headersTable
 }
 
 // Create the spinner which will be displayed at the bottom.

--- a/pkg/renderer/printer.go
+++ b/pkg/renderer/printer.go
@@ -51,6 +51,11 @@ func (p *Printer) startText() string {
 		Sprintf(p.BuildInfo["version"])
 
 	text := fmt.Sprintf("%s %s\nListening on http://%s:%d", primary, version, p.Addr, p.Port)
+
+	if p.Details {
+		text = fmt.Sprintf("%s\nDetails: %t", text, p.Details)
+	}
+
 	return text
 }
 

--- a/pkg/renderer/printer_test.go
+++ b/pkg/renderer/printer_test.go
@@ -19,6 +19,23 @@ func TestStartText(t *testing.T) {
 	}
 }
 
+func TestStartTextWithDetails(t *testing.T) {
+	pterm.DisableColor()
+	printer := Printer{
+		Addr:      "localhost",
+		Port:      8080,
+		BuildInfo: map[string]string{"version": "dev"},
+		Details:   true}
+	result := printer.startText()
+	expected := fmt.Sprintf(
+		"Request Hole %s\nListening on http://%s:%d\nDetails: %t", "dev",
+		printer.Addr, printer.Port, printer.Details)
+
+	if result != expected {
+		t.Errorf("Expected %s, got %s", expected, result)
+	}
+}
+
 func TestIncomingRequestText(t *testing.T) {
 	pterm.DisableColor()
 	printer := Printer{}

--- a/pkg/renderer/printer_test.go
+++ b/pkg/renderer/printer_test.go
@@ -34,3 +34,27 @@ func TestIncomingRequestText(t *testing.T) {
 		t.Errorf("Expected %s, got %s", expected, result)
 	}
 }
+
+func TestIncomingRequestHeadersTables(t *testing.T) {
+	pterm.DisableColor()
+	printer := Printer{}
+	headers := map[string][]string{
+		"hello": {"world", "foobar"},
+		"foo":   {"bar"},
+	}
+	result := printer.incomingRequestHeadersTable(headers)
+
+	headersForTable := [][]string{}
+	headersForTable = append(headersForTable, []string{"Header", "Value"})
+	headersForTable = append(headersForTable, []string{"foo", "bar"})
+	headersForTable = append(headersForTable, []string{"hello", "world,foobar"})
+
+	expected, err := pterm.DefaultTable.WithHasHeader().WithData(headersForTable).Srender()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if result != expected {
+		t.Errorf("Expected %s, got %s", expected, result)
+	}
+}

--- a/pkg/renderer/renderer.go
+++ b/pkg/renderer/renderer.go
@@ -18,5 +18,5 @@ type Renderer interface {
 	// Fatal is used when we need to display a message and should always exit the CLI.
 	Fatal(error)
 
-	IncomingRequest(logrequest.RequestFields, string)
+	IncomingRequest(logrequest.RequestFields, string, map[string][]string)
 }

--- a/pkg/server/http.go
+++ b/pkg/server/http.go
@@ -63,6 +63,6 @@ func (s *Http) logRequest(next http.Handler) http.Handler {
 		lr := logrequest.LogRequest{Request: r, Writer: w, Handler: next}
 		fields := lr.ToFields()
 		params := logparams.LogParams{Request: r, HidePrefix: true}
-		s.Output.IncomingRequest(fields, params.ToString())
+		s.Output.IncomingRequest(fields, params.ToString(), r.Header)
 	})
 }


### PR DESCRIPTION
This will print all headers in a table under the incoming request when the --details flag is passed to the CLI.

Header keys are sorted alphabetically.

Default option for the flag is set to false.

Example:

<img width="468" alt="Screen Shot 2021-05-31 at 11 13 03 AM" src="https://user-images.githubusercontent.com/100900/120242687-37b07880-c201-11eb-807f-8aa236888082.png">
